### PR TITLE
1: fixed fatal error when connection limit is reached

### DIFF
--- a/connmanager/conn_count_manager.go
+++ b/connmanager/conn_count_manager.go
@@ -17,12 +17,15 @@ type SimpleConnCountManager struct {
 }
 
 func NewSimpleConnCountManager(connLimit int) *SimpleConnCountManager {
-	return &SimpleConnCountManager{
+	res := &SimpleConnCountManager{
 		connCount:     0,
 		connLimit:     connLimit,
 		connCountLock: sync.RWMutex{},
 		cond:          *sync.NewCond(&sync.Mutex{}),
 	}
+	// sync.Cond must be Locked before Waiting on it
+	res.cond.L.Lock()
+	return res
 }
 
 func (c *SimpleConnCountManager) getConnCount() int {


### PR DESCRIPTION
`sync.Cond` must be Locked before Waiting on it. Locked the `sync.Cond` in `NewSimpleConnCountManager()` before returning the instance.